### PR TITLE
Set the default language to British English

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,5 +28,7 @@
 	"scripts": ["static/lib/client.js"],
 	"templates": "static/templates",
 	"less": ["static/style.less"],
-	"languages": "public/language"
+	"languages": "public/language",
+	"defaultLang": "en_GB"
+
 }


### PR DESCRIPTION
On boards that are set to `en_US`, the localization will display the keys, as opposed to the actual messages. This makes the default language British English, and compels the system to always display a real message even if the language file isn't available for your plugin.
