### PR TITLE
Ability to ignore chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.sublime*

--- a/library.js
+++ b/library.js
@@ -6,6 +6,7 @@
     var Socket = module.parent.require('./socket.io/modules'),
         User = module.parent.require('./user'),
         db = module.parent.require('./database'),
+        plugins = module.parent.require('./plugins'),
         async = module.parent.require('async'),
         helpers = module.parent.require('./controllers/helpers'),
         nconf = module.parent.require('nconf'),
@@ -151,6 +152,12 @@
      * It adds an user to the ignore list
      */
     Socket.ignoreUser = function (socket, data, callback) {
+        plugins.fireHook('action:plugin.ignore-users.toggled', {
+            uid: socket.uid,
+            ignoreduid: data.ignoreduid,
+            ignored: true
+        });
+
         db.setAdd('ignored:' + socket.uid, data.ignoreduid, callback);
     };
 
@@ -158,6 +165,12 @@
      * It removes an user from the ignore list
      */
     Socket.unignoreUser = function (socket, data, callback) {
+        plugins.fireHook('action:plugin.ignore-users.toggled', {
+            uid: socket.uid,
+            ignoreduid: data.ignoreduid,
+            ignored: false
+        });
+
         db.setRemove('ignored:' + socket.uid, data.ignoreduid, callback);
     };
 

--- a/library.js
+++ b/library.js
@@ -116,13 +116,17 @@
     plugin.checkIgnoredAccount = function (data, callback) {
         try {
             if (data.uid && data.uid !== data.userData.uid) {
-                User.isIgnored(data.uid, data.userData.uid, function (err, ignored) {
+                async.parallel({
+                    isIgnored: async.apply(User.isIgnored, data.uid, data.userData.uid),
+                    isIgnoredForChat: async.apply(User.isIgnoredForChat, data.uid, data.userData.uid),
+                }, function(err, ignored) {
                     if (err) {
                         console.error("[PROFILE] Error while checking if an user is ignored " + data.userData.uid, e);
                         return callback(null, data);
                     }
                     
-                    data.userData.isIgnored = ignored;
+                    data.userData.isIgnored = ignored.isIgnored;
+                    data.userData.isIgnoredForChat = ignored.isIgnoredForChat;
                     callback(null, data);
                 });
             } else {
@@ -175,6 +179,46 @@
     };
 
     /**
+     * It checks if an user (uid) has another user (otheruid) in the chat ignore list
+     */
+    User.isIgnoredForChat = function (uid, otheruid, callback) {
+        db.isSetMember('ignored:chat:' + uid, otheruid, callback);
+    };
+
+    /**
+     * It returns an user's chat ignore list
+     */
+    User.getIgnoredUsersForChat = function (uid, callback) {
+        db.getSetMembers('ignored:chat:' + uid, callback);
+    };
+
+    /**
+     * It adds an user to the chat ignore list
+     */
+    Socket.ignoreUserForChat = function (socket, data, callback) {
+        plugins.fireHook('action:plugin.ignore-users.chat.toggled', {
+            uid: socket.uid,
+            ignoreduid: data.ignoreduid,
+            ignored: true
+        });
+
+        db.setAdd('ignored:chat:' + socket.uid, data.ignoreduid, callback);
+    };
+
+    /**
+     * It removes an user from the chat ignore list
+     */
+    Socket.unignoreUserForChat = function (socket, data, callback) {
+        plugins.fireHook('action:plugin.ignore-users.chat.toggled', {
+            uid: socket.uid,
+            ignoreduid: data.ignoreduid,
+            ignored: false
+        });
+
+        db.setRemove('ignored:chat:' + socket.uid, data.ignoreduid, callback);
+    };
+
+    /**
      * It flags the ignored user's threads. Then, the threads are hidden.
      */
     plugin.filterIgnoredTopics = function (data, callback) {
@@ -189,6 +233,28 @@
             callback(null, data);
         })
         
+    };
+
+    /**
+     * If a user attempts to message somebody who has ignored them, show them an error message
+     */
+    plugin.filterIgnoredChats = function (chats, callback) {
+        console.log(chats.data.roomId);
+        db.getSortedSetRevRange('chat:room:' + chats.data.roomId + ':uids', 0, -1, function(err, uids) {
+            console.log(uids);
+            async.each(uids, function(uid, next) {
+                User.isIgnoredForChat(uid, chats.uid, function(err, ignored) {
+                    if (ignored) {
+                        return next(new Error('[[error:chat-restricted]]'));
+                    }
+
+                    next(null);
+                });
+            }, function(err) {
+                return callback(err, chats);
+            });
+        });
+        //User.isIgnoredForChat(data., otheruid
     };
     
     /*plugin.testNotificationPushed = function name(params) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-ignore-users",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A NodeBB plugin for ignoring posts from certain users",
   "main": "library.js",
   "repository": {
@@ -21,7 +21,7 @@
     "url": "https://github.com/exo-do/nodebb-plugin-ignore-users/issues"
   },
     "nbbpm": {
-    "compatibility": "^1.0.0"
+    "compatibility": "^1.1.0"
   },
   "readmeFilename": "README.md",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -23,6 +23,10 @@
 		{
 			"hook": "filter:category.topics.get",
 			"method": "filterIgnoredTopics"
+		},
+		{
+			"hook": "filter:messaging.send",
+			"method": "filterIgnoredChats"
 		}
 	],
 	"scripts": ["static/lib/client.js"],

--- a/public/language/en_GB/ignored.json
+++ b/public/language/en_GB/ignored.json
@@ -8,5 +8,14 @@
 	"ignored_no_one": "Your ignore list is empty :)",
 	"ignored_post": "This message is hidden because its author is in your ignored list.",
 	"ignoring_confirmation": "You are now ignoring: %1.",
-	"unignoring_confirmation": "You are no longer ignoring %1 anymore."
+	"unignoring_confirmation": "You are no longer ignoring %1 anymore.",
+	"chat.ignore": "Ignore Chats",
+    "chat.unignore": "Unignore Chats",
+	"chat.ignored": "Ignored Chats",
+	"chat.ignore_user": "Ignore user's chats",
+	"chat.unignore_user": "Unignore user's chats",
+	"chat.ignored_list": "Ignored List for Chats",
+	"chat.ignored_no_one": "Your ignore list for chats is empty :)",
+	"chat.ignoring_confirmation": "You are now ignoring %1's chats",
+	"chat.unignoring_confirmation": "You are no longer ignoring %1's chats anymore."
 }

--- a/static/lib/client.js
+++ b/static/lib/client.js
@@ -30,10 +30,18 @@
                 //If not, then he/she is visualizing another user profile, so the link must show the option to igonore the user.
                 //To show the initial value of the text in the link, we should evaluate if the user is already ignored or not.
                 var translationText = ajaxify.data.isIgnored ? '[[ignored:unignore_user]]' : '[[ignored:ignore_user]]';
-                var icon = ajaxify.data.isIgnored ? 'fa fa-eye' : 'fa fa-eye-slash';
+                var icon = ajaxify.data.isIgnored ? 'fa fa-fw fa-eye' : 'fa fa-fw fa-eye-slash';
+
+                var chatTranslationText = ajaxify.data.isIgnoredForChat ? '[[ignored:chat.unignore_user]]' : '[[ignored:chat.ignore_user]]';
+                var chatIcon = ajaxify.data.isIgnoredForChat ? 'fa fa-fw fa-volume-up' : 'fa fa-fw fa-volume-off';
+
                 require(['translator'], function(translator) {
                      translator.translate(translationText, function(translated) {
                         $('.dropdown-menu.dropdown-menu-right').append('<li><a class="ignore-user '+icon+'" href="#" >'+translated+'<a/></li>');
+                    });
+
+                     translator.translate(chatTranslationText, function(translated) {
+                        $('.dropdown-menu.dropdown-menu-right').append('<li><a class="ignore-user-chat '+chatIcon+'" href="#" >'+translated+'<a/></li>');
                     });
                 }); 
                 
@@ -96,6 +104,17 @@
 
             return false;
         });
+
+        $('.account').on('click', 'a.ignore-user-chat', function () {     
+            //Execute the (un)ignore action for chat
+            toggleIgnoreUserForChat({
+                id: ajaxify.data.uid,
+                name: ajaxify.data.username,
+                ignored: ajaxify.data.isIgnoredForChat
+            }, toggleIgnoreProfileForChat);
+
+            return false;
+        });
     }
     
     function addIgnoredListHandlers() {
@@ -125,6 +144,35 @@
 
             //Show the user a warning
             var translationString = user.ignored ? '[[ignored:unignoring_confirmation,'+user.name+']]' : '[[ignored:ignoring_confirmation,'+user.name+']]';
+            
+            require(['translator'], function(translator) {
+                translator.translate(translationString, function(translated) {
+                        app.alert({
+                            message: translated,
+                            type: 'success',
+                            timeout: 5000
+                        });
+                    });
+                }); 
+
+            callback(user);
+        });
+    }
+
+    /**
+     * Ignore or unignore the selected user for chat
+     */
+    function toggleIgnoreUserForChat(user, callback) {
+        socket.emit(user.ignored ? 'modules.unignoreUserForChat' : 'modules.ignoreUserForChat', {
+            ignoreduid: user.id
+        }, function (err, res) {
+
+            if (err) {
+                return;
+            }
+
+            //Show the user a warning
+            var translationString = user.ignored ? '[[ignored:chat.unignoring_confirmation,'+user.name+']]' : '[[ignored:chat.ignoring_confirmation,'+user.name+']]';
             
             require(['translator'], function(translator) {
                 translator.translate(translationString, function(translated) {
@@ -191,6 +239,25 @@
         }); 
             
         ajaxify.data.isIgnored = !user.ignored;
+        
+    }
+
+    /**
+     * Mark the selected user profile as ignored for chat
+     */
+    function toggleIgnoreProfileForChat(user) {
+        
+        var textToTranslate = !ajaxify.data.isIgnoredForChat ? '[[ignored:chat.unignore_user]]' : '[[ignored:chat.ignore_user]]';
+        
+        require(['translator'], function(translator) {
+        translator.translate(textToTranslate, function(translated) {
+                $('a.ignore-user-chat').text(translated);
+                $('a.ignore-user-chat').toggleClass('fa-volume-off');
+                $('a.ignore-user-chat').toggleClass('fa-volume-up');
+            });
+        }); 
+            
+        ajaxify.data.isIgnoredForChat = !user.ignored;
         
     }
     


### PR DESCRIPTION
- Added new hooks: `action:plugin.ignore-users.toggled` and `action:plugin.ignore-users.chat.toggled`
- Ability to ignore user's chats from their profile dropdown
- If ignored, user will receive this error from core: "This user has restricted their chat messages. They must follow you before you can chat with them", so it doesn't look like they specifically ignored that user
